### PR TITLE
[Build] Adds Silk Network PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo apt-get -qq update
   - sudo apt-get install -y build-essential libtool autotools-dev autoconf pkg-config libssl-dev libcrypto++-dev
   - sudo apt-get install -y libboost-all-dev
-  - sudo add-apt-repository -y ppa:bitcoin/bitcoin
+  - sudo add-apt-repository -y ppa:silknetwork/silknetwork
   - sudo apt-get update -y && sudo apt-get install -y libdb4.8-dev libdb4.8++-dev
   - sudo apt-get install -y libminiupnpc-dev
   - sudo apt-get install -y libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libcrypto++-dev

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ for Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be inst
 
     sudo apt-get install libboost-all-dev
 
- db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
+ db4.8 packages are available [here](https://launchpad.net/~silknetwork/+archive/ubuntu/silknetwork).
  You can add the repository using the following command:
 
-        sudo add-apt-repository ppa:bitcoin/bitcoin
+        sudo add-apt-repository ppa:silknetwork/silknetwork
         sudo apt-get update
 
  Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -66,7 +66,7 @@ for Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be inst
  db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
  You can add the repository using the following command:
 
-        sudo add-apt-repository ppa:bitcoin/bitcoin
+        sudo add-apt-repository ppa:silknetwork/silknetwork
         sudo apt-get update
 
  Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -20,7 +20,7 @@ First install depends:
 
     sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
     sudo apt-get install -y libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libboost-all-dev
-    sudo add-apt-repository ppa:bitcoin/bitcoin && sudo apt-get update && sudo apt-get install -y libdb4.8-dev libdb4.8++-dev
+    sudo add-apt-repository ppa:silknetwork/silknetwork && sudo apt-get update && sudo apt-get install -y libdb4.8-dev libdb4.8++-dev
     sudo apt-get install -y git libminiupnpc-dev libzmq3-dev libqt4-dev libprotobuf-dev protobuf-compiler libqrencode-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libcrypto++-dev
 
 Second install the toolchains:


### PR DESCRIPTION
<!--- Remove sections that do not apply -->


#### What is the purpose of this pull request (PR)?
Replaces the bitcoin PPA with a dedicated Silk Network PPA for Ubuntu builds.


#### Any background context to help the reviewer?
Berkeley Database 4.8 is required as a dependency to build Silk-Core from source. Silk-Core is incompatible with the latest version (5.3 I think) and v4.8 is no longer available via the standard apt-get install or apt install commands. 


#### Was this PR tested and how?
Tested locally and in Travis successfully.

