### PR TITLE
Removes unneeded functions for checking centralised checkpoints.

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -417,21 +417,6 @@ bool SendSyncCheckpoint(uint256 hashCheckpoint)
     return true;
 }
 
-// Is the sync-checkpoint too old?
-bool IsSyncCheckpointTooOld(unsigned int nSeconds)
-{
-    static bool fMain = Params().NetworkIDString() == "main";
-    if (!fMain) return false; // Testnet has no checkpoints
-
-    LOCK(cs_hashSyncCheckpoint);
-    // sync-checkpoint should always be accepted block
-    assert(mapBlockIndex.count(hashSyncCheckpoint));
-    const CBlockIndex* pindexSync = mapBlockIndex[hashSyncCheckpoint];
-    assert(pindexSync->nStatus & BLOCK_HAVE_DATA);
-
-    return (pindexSync->GetBlockTime() + nSeconds < GetAdjustedTime());
-}
-
 }  // namespace CheckpointsSync
 
 

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -63,7 +63,6 @@ namespace CheckpointsSync
     void AskForPendingSyncCheckpoint(CNode* pfrom);
     bool SetCheckpointPrivKey(std::string strPrivKey);
     bool SendSyncCheckpoint(uint256 hashCheckpoint);
-    bool IsSyncCheckpointTooOld(unsigned int nSeconds);
 
 }  //namespace CheckpointsSync
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3788,14 +3788,6 @@ string GetWarnings(string strFor)
         strStatusBar = strMintWarning;
     }
 
-    // ppcoin: should not enter safe mode for longer invalid chain
-    // ppcoin: if sync-checkpoint is too old do not enter safe mode
-    if (CheckpointsSync::IsSyncCheckpointTooOld(60 * 60 * 24 * 10))
-    {
-        nPriority = 100;
-        strStatusBar = "WARNING: Checkpoint is too old. Wait for block chain to download, or notify developers of the issue.";
-    }
-
     // Misc warnings like out of disk space and clock is wrong
     if (strMiscWarning != "")
     {


### PR DESCRIPTION
#### What is the purpose of this pull request (PR)?

Removes unneeded functions for checking centralised checkpoints.

#### Any background context to help the reviewer?

Warning message showing on Qt wallet was not relevant as centralised checkpoints are not used.

#### Was this PR tested and how?

Wallet builds and no longer displays WARNING: Checkpoint is too old. Wait for the blockchain

#### Does this PR resolve an open issue (reference issue #)?

Fixes issue or JIRA tasks:

#28 