### PR TITLE
[Qt] Fix memory use display issue #26

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -791,13 +791,8 @@ void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
 {
     ui->mempoolNumberTxs->setText(QString::number(numberOfTxs));
 
-    if (dynUsage < 1024)
-        ui->mempoolSize->setText(QString::number(dynUsage, 'f', 2) + " bytes");
+    if (dynUsage < 1000000)
+        ui->mempoolSize->setText(QString::number(dynUsage/1000.0, 'f', 2) + " KB");
     else
-    {
-        if (dynUsage < 1048576)
-            ui->mempoolSize->setText(QString::number(dynUsage/1024.0, 'f', 2) + "  kilobytes");
-        else
-            ui->mempoolSize->setText(QString::number(dynUsage/1048576.0, 'f', 2) + " megabytes");
-    }
+        ui->mempoolSize->setText(QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
 }


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
#### What is the purpose of this pull request (PR)?
Fix memory use display issue in the Qt debug console.  

#### Was this PR tested and how?
Yes, on Ubuntu 16.04.

#### Does this PR resolve an open issue (reference issue #)?
Fixes issue #26 
