### PR TITLE
[Core] Add conf file if file is not found

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -74,7 +74,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/program_options/detail/config_file.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/thread.hpp>
@@ -435,10 +434,9 @@ static void WriteConfigFile(FILE* configFile)
 {
     std::string sRPCpassword = "rpcpassword=" + GenerateRandomString(RandomIntegerRange(18, 24)) + "\n";
     std::string sUserID = "rpcuser=" + GenerateRandomString(RandomIntegerRange(7, 11)) + "\n";
-    std::string sRPCPort = "rpcport=" + boost::lexical_cast<std::string>(BaseParams().RPCPort()) + "\n";
     fputs (sUserID.c_str(), configFile);
     fputs (sRPCpassword.c_str(), configFile);
-    fputs (sRPCPort.c_str(), configFile);
+    fputs ("rpcport=16662\n", configFile);
     fputs ("listen=1\n", configFile);
     fputs ("server=1\n", configFile);
     fputs ("daemon=1\n", configFile);
@@ -501,7 +499,7 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
     if (!streamConfig.good()){
         // Create silk.conf if it does not exist
         FILE* configFile = fopen(GetConfigFile().string().c_str(), "a");
-        if (configFile == NULL) {
+        if (configFile != NULL) {
             // Write silk.conf file with random username and password.
             WriteConfigFile(configFile);
             // New silk.conf file written, now read it.


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
#### What is the purpose of this pull request (PR)?
Add silk.conf file to the data directory if the file does not exist.  Uses random username and passwords.  Uses these default values:
```
rpcport=16662
listen=1
server=1
daemon=1
stakegen=1
staking=1
testnet=0
```
Fixes issue #20 
