### PR TITLE
Remove startup flags from auto-generated conf

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -437,12 +437,6 @@ static void WriteConfigFile(FILE* configFile)
     fputs (sUserID.c_str(), configFile);
     fputs (sRPCpassword.c_str(), configFile);
     fputs ("rpcport=16662\n", configFile);
-    fputs ("listen=1\n", configFile);
-    fputs ("server=1\n", configFile);
-    fputs ("daemon=1\n", configFile);
-    fputs ("stakegen=1\n", configFile);
-    fputs ("staking=1\n", configFile);
-    fputs ("testnet=0\n", configFile);
     fclose(configFile);
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request (PR)?

Removal of flags which can differ from system to system.

Upon creation of the silk.conf only the required flags for startup are now created.

#### Any background context to help the reviewer?

Config currently created contains flags that are not standard across any system running Silk.

#### Was this PR tested and how?

Tested. silk.conf creation completes successfully.

#### Does this PR resolve an open issue (reference issue #)?

Fixes issue or JIRA tasks:

#46 

#### More Questions:


- Does the knowledge base need an update?

No

- Does this PR add or change dependencies?

No

- Does this PR change or fork the blockchain

No