### PR TITLE
[Build] Increase Minium Boost Version to 1.47

### DIFF
--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -33,7 +33,11 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
+<<<<<<< HEAD
 #serial 23
+=======
+#serial 27
+>>>>>>> bc83e23... Set minimum required Boost to 1.47.0
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -72,7 +76,7 @@ AC_ARG_WITH([boost-libdir],
 )
 
 if test "x$want_boost" = "xyes"; then
-    boost_lib_version_req=ifelse([$1], ,1.20.0,$1)
+    boost_lib_version_req=ifelse([$1], ,1.47.0,$1)
     boost_lib_version_req_shorten=`expr $boost_lib_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
     boost_lib_version_req_major=`expr $boost_lib_version_req : '\([[0-9]]*\)'`
     boost_lib_version_req_minor=`expr $boost_lib_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
@@ -95,7 +99,11 @@ if test "x$want_boost" = "xyes"; then
       x86_64)
         libsubdirs="lib64 libx32 lib lib64"
         ;;
+<<<<<<< HEAD
       ppc64|s390x|sparc64|aarch64)
+=======
+      ppc64|s390x|sparc64|aarch64|ppc64le)
+>>>>>>> bc83e23... Set minimum required Boost to 1.47.0
         libsubdirs="lib64 lib lib64"
         ;;
     esac

--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -33,11 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-<<<<<<< HEAD
-#serial 23
-=======
 #serial 27
->>>>>>> bc83e23... Set minimum required Boost to 1.47.0
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -99,11 +95,7 @@ if test "x$want_boost" = "xyes"; then
       x86_64)
         libsubdirs="lib64 libx32 lib lib64"
         ;;
-<<<<<<< HEAD
-      ppc64|s390x|sparc64|aarch64)
-=======
       ppc64|s390x|sparc64|aarch64|ppc64le)
->>>>>>> bc83e23... Set minimum required Boost to 1.47.0
         libsubdirs="lib64 lib lib64"
         ;;
     esac


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
#### What is the purpose of this pull request (PR)?

Increases the minimum boost version to 1.47.  See PR https://github.com/bitcoin/bitcoin/pull/8920
#### Any background context to help the reviewer?

@fanquake from the original PR:

> Boost is on the way out, but in the mean time, having the minimum set to 1.20.0 is misleading, and can lead to issues like #8868.
> 
> 1.47.0 is the first version to include Chrono. See #8875 for some history.
#### Was this PR tested and how?

Not yet.
