### PR TITLE
Fix for byteswap errors

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -44,7 +44,8 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-    $ brew install git autoconf automake libtool boost miniupnpc openssl pkg-config protobuf qt berkeley-db4
+    $ brew install git autoconf automake libtool boost miniupnpc openssl pkg-config qt berkeley-db4
+    $ brew install homebrew/versions/protobuf260 --c++11
 
 Because of OS X having LibreSSL installed we have to tell the compiler where OpenSSL is located:
 


### PR DESCRIPTION
#### What is the purpose of this pull request (PR)?

Updates readme for correct dependency as the standard install of protobuf with Homebrew causes errors with byteswap and protobuf260 --c++11 must be installed to circumvent this issue.

#### Any background context to help the reviewer?
This error was local on my machine and solved locally.


#### Was this PR tested and how?
Tested locally, no further testing required.