### PR TITLE
[Util] Fix default RPC port written to conf file

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -436,7 +436,7 @@ static void WriteConfigFile(FILE* configFile)
     std::string sUserID = "rpcuser=" + GenerateRandomString(RandomIntegerRange(7, 11)) + "\n";
     fputs (sUserID.c_str(), configFile);
     fputs (sRPCpassword.c_str(), configFile);
-    fputs ("rpcport=16662\n", configFile);
+    fputs ("rpcport=16663\n", configFile);
     fclose(configFile);
 }
 


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Fix default RPC port written to conf file as reported in issue #74.
Still needs testing.
