### PR TITLE
[Net] Adds silknetwork.net seeders

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -217,8 +217,8 @@ public:
         assert(hashGenesisBlock == uint256("0x000000251356c62e0aa14c63e2b0db2a05ac0d3316ea5000c797a281be8c9fd7"));
         assert(genesis.hashMerkleRoot == uint256("0x73d6f8c42dfa8c9175b8bf4bf75ebfd10d22b0b6b1a39a82ce0e408447418e4b"));
 
-        //vSeeds.push_back(CDNSSeedData("silknetwork.net", "slk1.silknetwork.net"));
-        //vSeeds.push_back(CDNSSeedData("silknetwork.net", "slk2.silknetwork.net"));
+        vSeeds.push_back(CDNSSeedData("silknetwork.net", "slk1.silknetwork.net"));
+        vSeeds.push_back(CDNSSeedData("silknetwork.net", "slk2.silknetwork.net"));
         vSeeds.push_back(CDNSSeedData("dnsseeder.io", "silk.dnsseeder.io"));
         vSeeds.push_back(CDNSSeedData("dnsseeder.com", "silk.dnsseeder.com"));
         vSeeds.push_back(CDNSSeedData("dnsseeder.host", "silk.dnsseeder.host"));


### PR DESCRIPTION
<!--- Remove sections that do not apply -->


#### What is the purpose of this pull request (PR)?
To uncomment out the silknetwork.net seeders.


#### Any background context to help the reviewer?
The silk.dnsseeder seeders no longer have a high cpu usage problem. A fresh build and clear data directory connects quickly with each set alone, as well as with both sets together. The silknetwork.net seeders have had the default address data cache raised from the default of 10 to 100 to improve their connectivity by expanding the range of possible topologies. Currently there are about 90 total ip addresses in circulation with 20 - 30 that are consistently active. 

After syncing the full blockchain in about 5-10 minutes, the cpu usage drops to less than 1% of one core on a 4-core i5 processor using Ubuntu 16.04.1 64 bit.  


#### Was this PR tested and how?
Yes, explained above.


#### Does this PR resolve an open issue (reference issue #)?

Fixes issue or JIRA tasks:

#56 

