### PR TITLE
[PoS] Adds stake weight and related statistics and more

### DIFF
--- a/silk-qt.pro
+++ b/silk-qt.pro
@@ -513,6 +513,7 @@ HEADERS += \
     src/qt/coincontroltreewidget.h \
     src/qt/coincontroldialog.h \
     src/qt/clientmodel.h \
+    src/qt/calcdialog.h \
     src/qt/askpassphrasedialog.h \
     src/qt/addresstablemodel.h \
     src/qt/addressbookpage.h \
@@ -530,6 +531,7 @@ FORMS += \
     src/qt/forms/askpassphrasedialog.ui \
     src/qt/forms/coincontroldialog.ui \
     src/qt/forms/createmultisigaddrdialog.ui \
+    src/qt/forms/calcdialog.ui \
     src/qt/forms/dnspage.ui \
     src/qt/forms/editaddressdialog.ui \
     src/qt/forms/helpmessagedialog.ui \
@@ -634,6 +636,7 @@ SOURCES += \
     src/qt/addressbookpage.cpp \
     src/qt/addresstablemodel.cpp \
     src/qt/askpassphrasedialog.cpp \
+    src/qt/calcdialog.cpp \
     src/qt/clientmodel.cpp \
     src/qt/coincontroldialog.cpp \
     src/qt/coincontroltreewidget.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -78,6 +78,7 @@ QT_TS = \
 QT_FORMS_UI = \
   qt/forms/addressbookpage.ui \
   qt/forms/askpassphrasedialog.ui \
+  qt/forms/calcdialog.ui \
   qt/forms/coincontroldialog.ui \
   qt/forms/dnspage.ui \
   qt/forms/editaddressdialog.ui \
@@ -105,6 +106,7 @@ QT_MOC_CPP = \
   qt/moc_silkamountfield.cpp \
   qt/moc_silkgui.cpp \
   qt/moc_silkunits.cpp \
+  qt/moc_calcdialog.cpp \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
@@ -175,6 +177,7 @@ SILK_QT_H = \
   qt/silkamountfield.h \
   qt/silkgui.h \
   qt/silkunits.h \
+  qt/calcdialog.h \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \
@@ -279,6 +282,7 @@ SILK_QT_CPP = \
   qt/silkamountfield.cpp \
   qt/silkgui.cpp \
   qt/silkunits.cpp \
+  qt/calcdialog.cpp \
   qt/clientmodel.cpp \
   qt/csvmodelwriter.cpp \
   qt/guiutil.cpp \

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -5,8 +5,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef PPCOIN_KERNEL_H
-#define PPCOIN_KERNEL_H
+#ifndef SILK_KERNEL_H
+#define SILK_KERNEL_H
 
 #include "main.h"
 
@@ -37,4 +37,4 @@ unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);
 // Check stake modifier hard checkpoints
 bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum);
 
-#endif // PPCOIN_KERNEL_H
+#endif // SILK_KERNEL_H

--- a/src/qt/calcdialog.cpp
+++ b/src/qt/calcdialog.cpp
@@ -4,6 +4,16 @@
 
 #include "calcdialog.h"
 #include "ui_calcdialog.h"
+
+#include "transactiontablemodel.h"
+#include "transactiondesc.h"
+#include "transactionrecord.h"
+#include "walletmodel.h"
+#include "silkunits.h"
+
+#include "main.h"
+#include "wallet/wallet.h"
+
 #include <QString>
 
 calcDialog::calcDialog(QWidget *parent) :
@@ -25,12 +35,33 @@ void calcDialog::setModel(ClientModel *model)
 
 }
 
-
+// Calculates the percent profit within the user defined timeframe (in days)
 void calcDialog::pushButtonClicked()
 {
-	QString strUserSize = ui->blockSizeEdit->text();
-	double dUserBlock = strUserSize.toDouble();
-	double dMax = 1000;
+	float rate = 0;
+	CWalletTx tx;
+	CWalletTx ptx;
+	CWallet *wallet;
+	const TransactionRecord *wtx;
+	uint256 hash;
+
+	QString strRewardSize = ui->stakeDaysEdit->text(); // strUserSize, blockSizeEdit
+	float days = strRewardSize.toFloat();
+
+	//if (wtx->decomposeTransaction(wallet->hash, &tx)) 
+	{
+		if (tx.vin.size() == 1) 
+		{
+			rate = 100.0f * (wtx->credit + wtx->debit) / -wtx->debit;
+
+			//if (wallet->GetTransaction(tx->vin[0].prevout.hash, ptx)) 
+			{
+				days = (tx.nTime - ptx.nTime) / 86400.0f;
+
+				strRewardSize += "\n" + tr("%1% SLK staked in %2 days").arg(rate).arg(days);
+			}
+		}
+	}
 	
 }
 

--- a/src/qt/calcdialog.cpp
+++ b/src/qt/calcdialog.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-2016 Silk Network Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "calcdialog.h"
+#include "ui_calcdialog.h"
+#include <QString>
+
+calcDialog::calcDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::calcDialog)
+{
+    ui->setupUi(this);
+	
+	connect(ui->pushButton, SIGNAL(clicked()), this, SLOT(pushButtonClicked()));
+}
+
+calcDialog::~calcDialog()
+{
+    delete ui;
+}
+
+void calcDialog::setModel(ClientModel *model)
+{
+
+}
+
+
+void calcDialog::pushButtonClicked()
+{
+	QString strUserSize = ui->blockSizeEdit->text();
+	double dUserBlock = strUserSize.toDouble();
+	double dMax = 1000;
+	
+}
+
+void calcDialog::on_buttonBox_accepted()
+{
+	close();
+}

--- a/src/qt/calcdialog.h
+++ b/src/qt/calcdialog.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-2016 Silk Network Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef CALCDIALOG_H
+#define CALCDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class calcDialog;
+}
+class ClientModel;
+
+class calcDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit calcDialog(QWidget *parent = 0);
+    ~calcDialog();
+
+    void setModel(ClientModel *model);
+private slots:
+    void on_buttonBox_accepted();
+	void pushButtonClicked();
+
+private:
+    Ui::calcDialog *ui;
+};
+
+#endif // CALCDIALOG_H

--- a/src/qt/forms/calcdialog.ui
+++ b/src/qt/forms/calcdialog.ui
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>calcDialog</class>
+ <widget class="QDialog" name="calcDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>250</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Stake Calculator</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>250</y>
+     <width>161</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Ok</set>
+   </property>
+   <property name="centerButtons">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="blockSizeEdit">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>80</y>
+     <width>171</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="placeholderText">
+    <string>Enter Block Size</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>10</y>
+     <width>251</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>16</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Stake Calculator</string>
+   </property>
+   <property name="scaledContents">
+    <bool>false</bool>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>35</x>
+     <y>42</y>
+     <width>181</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <property name="lineWidth">
+    <number>1</number>
+   </property>
+   <property name="text">
+    <string>Calculate Optimal Block Sizes by Seeing Potential Reward</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="day9Label">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>130</y>
+     <width>41</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="lineWidth">
+    <number>1</number>
+   </property>
+   <property name="text">
+    <string>Result:</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="Result">
+   <property name="geometry">
+    <rect>
+     <x>100</x>
+     <y>130</y>
+     <width>41</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="lineWidth">
+    <number>1</number>
+   </property>
+   <property name="text">
+    <string>0</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButton">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>100</y>
+     <width>81</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Calculate</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>calcDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>calcDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/calcdialog.ui
+++ b/src/qt/forms/calcdialog.ui
@@ -32,7 +32,7 @@
     <bool>true</bool>
    </property>
   </widget>
-  <widget class="QLineEdit" name="blockSizeEdit">
+  <widget class="QLineEdit" name="stakeDaysEdit">
    <property name="geometry">
     <rect>
      <x>40</x>
@@ -82,7 +82,7 @@
     <number>1</number>
    </property>
    <property name="text">
-    <string>Calculate Optimal Block Sizes by Seeing Potential Reward</string>
+    <string>Calculate your PoS Rewards</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -572,12 +572,24 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Block Size:</string>
+            </property>
            </widget>
           </item>
           <item>
            <widget class="QLabel" name="labelBlockSize">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>0.00 SLK</string>
             </property>
            </widget>
           </item>

--- a/src/qt/silkgui.cpp
+++ b/src/qt/silkgui.cpp
@@ -1099,24 +1099,18 @@ void SilkGUI::updateWeight()
     if (!lockWallet)
         return;
 
-    nWeight = pwalletMain->GetStakeWeight();
+    nWeight = pwalletMain->GetStakeWeight() / COIN;
 }
 
 void SilkGUI::updateStakingIcon()
 {
     updateWeight();
 
-    if (nLastCoinStakeSearchInterval && nWeight) 
-    {
-            labelStakingIcon->setPixmap(QIcon(":/icons/staking_on").pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
-            labelStakingIcon->setToolTip(tr("Staking: On"));
-    }
-
-    /*if (nLastCoinStakeSearchInterval && nWeight)
+    if (nLastCoinStakeSearchInterval && nWeight)
     {
         uint64_t nWeight = this->nWeight;
         uint64_t nNetworkWeight = GetPoSKernelPS();
-        unsigned nEstimateTime = Params().PoSTargetSpacing() * nNetworkWeight / nWeight;
+        uint64_t nEstimateTime = Params().PoSTargetSpacing() * nNetworkWeight / nWeight;
 
         QString text;
         if (nEstimateTime < 60)
@@ -1136,12 +1130,9 @@ void SilkGUI::updateStakingIcon()
             text = tr("%n day(s)", "", nEstimateTime/(60*60*24));
         }
 
-        nWeight /= COIN;
-        nNetworkWeight /= COIN;
-
         labelStakingIcon->setPixmap(QIcon(":/icons/staking_on").pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
         labelStakingIcon->setToolTip(tr("Staking.<br>Your weight is %1<br>Network weight is %2<br>Expected time to earn reward is %3").arg(nWeight).arg(nNetworkWeight).arg(text));
-    }*/
+    }
     else
     {
 

--- a/src/qt/silkgui.cpp
+++ b/src/qt/silkgui.cpp
@@ -7,6 +7,7 @@
 #include "silkgui.h"
 
 #include "silkunits.h"
+#include "calcdialog.h"
 #include "clientmodel.h"
 #include "guiconstants.h"
 #include "guiutil.h"
@@ -356,6 +357,10 @@ void SilkGUI::createActions(const NetworkStyle *networkStyle)
     toggleHideAction = new QAction(networkStyle->getAppIcon(), tr("&Show / Hide"), this);
     toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
 
+    calcAction = new QAction(QIcon(":/icons/silk"), tr("&Stake Calculator"), this);
+    calcAction->setToolTip(tr("Open Stake Calculator"));
+    calcAction->setMenuRole(QAction::AboutRole);
+
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
     encryptWalletAction->setCheckable(true);
@@ -397,6 +402,9 @@ void SilkGUI::createActions(const NetworkStyle *networkStyle)
     connect(optionsAction, SIGNAL(triggered()), this, SLOT(optionsClicked()));
     connect(toggleHideAction, SIGNAL(triggered()), this, SLOT(toggleHidden()));
     connect(showHelpMessageAction, SIGNAL(triggered()), this, SLOT(showHelpMessageClicked()));
+
+    connect(calcAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
+    connect(calcAction, SIGNAL(triggered()), this, SLOT(calcClicked()));
 #ifdef ENABLE_WALLET
     if(walletFrame)
     {
@@ -442,6 +450,7 @@ void SilkGUI::createMenuBar()
     {
         settings->addAction(encryptWalletAction);
         settings->addAction(changePassphraseAction);
+        settings->addAction(calcAction);
         settings->addSeparator();
     }
     settings->addAction(optionsAction);
@@ -1148,6 +1157,12 @@ void SilkGUI::updateStakingIcon()
         else
             labelStakingIcon->setToolTip(tr("Staking: Off"));
     }
+}
+
+void SilkGUI::calcClicked()
+{
+    calcDialog dlg;
+    dlg.exec();
 }
 
 void SilkGUI::detectShutdown()

--- a/src/qt/silkgui.h
+++ b/src/qt/silkgui.h
@@ -135,6 +135,7 @@ private:
 
     QAction *openAction;
     QAction *showHelpMessageAction;
+    QAction *calcAction;
 
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
@@ -230,6 +231,8 @@ private slots:
     void aboutClicked();
     /** Show help message dialog */
     void showHelpMessageClicked();
+    /** Show Stake Calculator Dialog */
+    void calcClicked();
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);

--- a/src/qt/silkgui.h
+++ b/src/qt/silkgui.h
@@ -147,6 +147,8 @@ private:
     int spinnerFrame;
 
     uint64_t nWeight;
+    uint64_t nNetworkWeight;
+    CAmount nAmount;
 
     /** Create the main UI actions. */
     void createActions(const NetworkStyle *networkStyle);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -54,7 +54,15 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     }
     else if (wtx.IsCoinStake()) // ppcoin: coinstake transaction
     {
-        parts.append(TransactionRecord(hash, nTime, TransactionRecord::StakeMint, "", -nDebit, wtx.GetValueOut()));
+        TransactionRecord txrCoinStake = TransactionRecord(hash, nTime, TransactionRecord::StakeMint, "", -nDebit, wtx.GetValueOut());
+
+        CTxDestination address;
+        if (ExtractDestination(wtx.vout[1].scriptPubKey, address))
+        {
+            txrCoinStake.address = CSilkAddress(address).ToString();
+        }
+
+        parts.append(txrCoinStake); // Stake generation
     }
     else if (nNet > 0 || wtx.IsCoinBase())
     {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -411,6 +411,8 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::NameOp:
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::SendToSelf:
+    case TransactionRecord::StakeMint:
+        return lookupAddress(wtx->address, tooltip) + watchAddress;
     default:
         return tr("(n/a)") + watchAddress;
     }

--- a/src/rpc/rpcmisc.cpp
+++ b/src/rpc/rpcmisc.cpp
@@ -92,7 +92,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.ToStringIPPort() : string())));
     obj.push_back(Pair("ip",            addrSeenByPeer.ToStringIP()));
-    obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
+    obj.push_back(Pair("difficulty",    GetDifficulty(GetLastBlockIndex(chainActive.Tip(), true))));
     obj.push_back(Pair("testnet",       Params().TestnetToBeDeprecatedFieldRPC()));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {


### PR DESCRIPTION
<!--- Remove sections that do not apply -->


#### What is the purpose of this pull request (PR)?
Adds proper calculation of network-stake-weight, user-stake-weight, and expected time to stake. These stats can be seen in the GUI by hovering over the lightening bolt on the overview page or through the RPC console. The commands getstakinginfo and getmininginfo have been updated, and two new RPC commands have been added called getweight (returns the wallet's stake weight) and getmoneysupply (returns the current total money supply).

This PR also adds a stake-calculation dialog box, with which I will implement these new and improved stake statistics into a user-friendly and easy to find dialog box. I may add more advanced calculations and statistical projections if possible.

This will also add enhanced SplitBlock functionality, though it is not yet implemented.


More commits will be on their way to enhance functionality, but the commit related to stakeweight, et al is 100% working.


#### Any background context to help the reviewer?



#### Was this PR tested and how?
Over and over and over until the numbers were correct.

