### PR TITLE
Adds check to thwart timedrifters

### DIFF
--- a/silk-qt.pro
+++ b/silk-qt.pro
@@ -402,6 +402,7 @@ HEADERS += \
     src/noui.h \
     src/netbase.h \
     src/net.h \
+    src/ntp.h \
     src/mruset.h \
     src/miner.h \
     src/merkleblock.h \
@@ -583,6 +584,7 @@ SOURCES += \
     src/net.cpp \
     src/netbase.cpp \
     src/noui.cpp \
+    src/ntp.cpp \
     src/pow.cpp \
     src/protocol.cpp \
     src/pubkey.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -133,6 +133,7 @@ SILK_CORE_H = \
   netaddress.h \
   net.h \
   noui.h \
+  ntp.h \
   pow.h \
   protocol.h \
   pubkey.h \
@@ -204,6 +205,7 @@ libsilk_server_a_SOURCES = \
   miner.cpp \
   net.cpp \
   noui.cpp \
+  ntp.cpp \
   pow.cpp \
   rest.cpp \
   rpc/rpcblockchain.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -19,6 +19,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "ntp.h"
 #include "rpc/rpcregister.h"
 #include "rpc/rpcserver.h"
 #include "scheduler.h"
@@ -1420,7 +1421,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         MintStake(threadGroup, pwalletMain);
 #endif
 
-    // ********************************************************* Step 11: finished
+    // ********************************************************* Step 11: NTP synchronization
+
+    // Trusted NTP server, it's localhost by default.
+    strTrustedUpstream = GetArg("-ntp", "localhost");
+
+
+    // ********************************************************* Step 12: finished
 
     SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -865,6 +865,10 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
         return state.DoS(100, error("CheckTransaction() : size limits failed"),
                          REJECT_INVALID, "bad-txns-oversize");
 
+    //  Checks tx time in order to catch time drifting attacks
+    if (tx.nTime > GetAdjustedTime() + nMaxClockDrift)
+        return state.DoS(10, error("CTransaction::CheckTransaction() : timestamp is too far into the future"));
+
     // Check for negative or overflow output values
     CAmount nValueOut = 0;
     BOOST_FOREACH(const CTxOut& txout, tx.vout)

--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -1,0 +1,448 @@
+#ifdef WIN32
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#endif
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
+#include "init.h"
+#include "netbase.h"
+#include "net.h"
+#include "timedata.h"
+#include "threadsafety.h"
+#include "utiltime.h"
+#include "ui_interface.h"
+
+extern int GetRandInt(int nMax);
+
+/*
+ * NTP uses two fixed point formats.  The first (l_fp) is the "long"
+ * format and is 64 bits long with the decimal between bits 31 and 32.
+ * This is used for time stamps in the NTP packet header (in network
+ * byte order) and for internal computations of offsets (in local host
+ * byte order). We use the same structure for both signed and unsigned
+ * values, which is a big hack but saves rewriting all the operators
+ * twice. Just to confuse this, we also sometimes just carry the
+ * fractional part in calculations, in both signed and unsigned forms.
+ * Anyway, an l_fp looks like:
+ *
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |                         Integral Part                         |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |                         Fractional Part                       |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * REF http://www.eecis.udel.edu/~mills/database/rfc/rfc2030.txt
+ */
+
+
+typedef struct {
+  union {
+    uint32_t Xl_ui;
+    int32_t Xl_i;
+  } Ul_i;
+  union {
+    uint32_t Xl_uf;
+    int32_t Xl_f;
+  } Ul_f;
+} l_fp;
+
+
+inline void Ntp2Unix(const uint32_t &n, time_t &u) {
+    // Ntp's time scale starts in 1900, Unix in 1970.
+
+    u = n - 0x83aa7e80; // 2208988800 1970 - 1900 in seconds
+}
+
+inline void ntohl_fp(l_fp *n, l_fp *h) {
+    (h)->Ul_i.Xl_ui = ntohl((n)->Ul_i.Xl_ui);
+    (h)->Ul_f.Xl_uf = ntohl((n)->Ul_f.Xl_uf);
+}
+
+struct pkt {
+  uint8_t  li_vn_mode;     /* leap indicator, version and mode */
+  uint8_t  stratum;        /* peer stratum */
+  uint8_t  ppoll;          /* peer poll interval */
+  int8_t  precision;      /* peer clock precision */
+  uint32_t    rootdelay;      /* distance to primary clock */
+  uint32_t    rootdispersion; /* clock dispersion */
+  uint32_t refid;          /* reference clock ID */
+  l_fp    ref;        /* time peer clock was last updated */
+  l_fp    org;            /* originate time stamp */
+  l_fp    rec;            /* receive time stamp */
+  l_fp    xmt;            /* transmit time stamp */
+
+  uint32_t exten[1];       /* misused */
+  uint8_t  mac[5 * sizeof(uint32_t)]; /* mac */
+};
+
+const int nServersCount = 162;
+
+std::string NtpServers[162] = {
+    // Microsoft
+    "time.windows.com",
+
+    // Google
+    "time1.google.com",
+    "time2.google.com",
+    "time3.google.com",
+    "time4.google.com",
+
+    // Hurricane Electric
+    "clock.sjc.he.net",
+    "clock.nyc.he.net",
+
+    // SixXS
+    "ntp.sixxs.net",
+    "ntp.eu.sixxs.net",
+    "ntp.us.sixxs.net",
+    "ntp.ap.sixxs.net",
+
+    // Russian Federation
+    "ntp.karelia.pro",
+    "ntp.alpet.me",
+    "aviel.alpet.me",
+    "ntp.sampo.ru",
+    "ntp.szt.ru",
+    "ntp.ix.ru",
+    "ntp1.stratum2.ru",
+    "ntp2.stratum2.ru",
+    "ntp3.stratum2.ru",
+    "ntp4.stratum2.ru",
+    "ntp5.stratum2.ru",
+    "ntp6.stratum2.ru",
+    "ntp7.stratum2.ru",
+    "ntp1.stratum1.ru",
+    "ntp2.stratum1.ru",
+    "ntp3.stratum1.ru",
+    "ntp4.stratum1.ru",
+    "ntp1.vniiftri.ru",
+    "ntp2.vniiftri.ru",
+    "ntp3.vniiftri.ru",
+    "ntp4.vniiftri.ru",
+    "ntp21.vniiftri.ru",
+    "ntp1.niiftri.irkutsk.ru",
+    "ntp2.niiftri.irkutsk.ru",
+    "vniiftri.khv.ru",
+    "vniiftri2.khv.ru",
+    "ntp0.zenon.net",
+    "ntp.mobatime.ru",
+    "0.ru.pool.ntp.org",
+    "1.ru.pool.ntp.org",
+    "2.ru.pool.ntp.org",
+    "3.ru.pool.ntp.org",
+
+    // United States
+    "tock.cs.unlv.edu",
+    "timex.cs.columbia.edu",
+    "tick.cs.unlv.edu",
+    "sundial.columbia.edu",
+    "ntp-1.ece.cmu.edu",
+    "ntp-2.ece.cmu.edu",
+    "ntp1.cs.wisc.edu",
+    "ntp2.cs.wisc.edu",
+    "ntp3.cs.wisc.edu",
+    "ntp-01.caltech.edu",
+    "ntp-02.caltech.edu",
+    "ntp-03.caltech.edu",
+    "ntp-04.caltech.edu",
+    "nist1-pa.ustiming.org",
+    "time.nist.gov",
+    "time-a.nist.gov",
+    "time-b.nist.gov",
+    "time-c.nist.gov",
+    "time-d.nist.gov",
+    "time-nw.nist.gov",
+    "nist1-macon.macon.ga.us",
+    "nist.netservicesgroup.com",
+    "nisttime.carsoncity.k12.mi.us",
+    "nist1-lnk.binary.net",
+    "wwv.nist.gov",
+    "time-a.timefreq.bldrdoc.gov",
+    "time-b.timefreq.bldrdoc.gov",
+    "time-c.timefreq.bldrdoc.gov",
+    "utcnist.colorado.edu",
+    "utcnist2.colorado.edu",
+    "ntp-nist.ldsbc.net",
+    "nist1-lv.ustiming.org",
+    "time-nw.nist.gov",
+    "nist-time-server.eoni.com",
+    "nist-time-server.eoni.com",
+    "ntp1.bu.edu",
+    "ntp2.bu.edu",
+    "ntp3.bu.edu",
+    "0.us.pool.ntp.org",
+    "1.us.pool.ntp.org",
+    "2.us.pool.ntp.org",
+    "3.us.pool.ntp.org",
+    "wwv.otc.psu.edu",
+    "otc1.psu.edu",
+    "otc2.psu.edu",
+    "now.okstate.edu",
+    "ntp.colby.edu",
+    "bonehed.lcs.mit.edu",
+    "ntp-s1.cise.ufl.edu",
+
+    // South Africa
+    "ntp1.meraka.csir.co.za",
+    "ntp.is.co.za",
+    "ntp2.is.co.za",
+    "igubu.saix.net",
+    "ntp1.neology.co.za",
+    "ntp2.neology.co.za",
+    "tick.meraka.csir.co.za",
+    "tock.meraka.csir.co.za",
+    "ntp.time.org.za",
+    "ntp1.meraka.csir.co.za",
+    "ntp2.meraka.csir.co.za",
+    "0.za.pool.ntp.org",
+    "1.za.pool.ntp.org",
+    "2.za.pool.ntp.org",
+    "3.za.pool.ntp.org",
+
+    // Italy
+    "ntp0.ien.it",
+    "ntp1.ien.it",
+    "ntp2.ien.it",
+    "ntp1.inrim.it",
+    "ntp2.inrim.it",
+    "0.it.pool.ntp.org",
+    "1.it.pool.ntp.org",
+    "2.it.pool.ntp.org",
+    "3.it.pool.ntp.org",
+
+    // Netherlands
+    "ntp0.nl.net",
+    "ntp1.nl.net",
+    "ntp2.nl.net",
+    "ntp.utwente.nl",
+    "0.nl.pool.ntp.org",
+    "1.nl.pool.ntp.org",
+    "2.nl.pool.ntp.org",
+    "3.nl.pool.ntp.org",
+
+    // United Kingdom
+    "ntp2d.mcc.ac.uk",
+    "ntp2c.mcc.ac.uk",
+    "ntp2b.mcc.ac.uk",
+    "ntp.exnet.com",
+    "ntp.cis.strath.ac.uk",
+    "ntppub.le.ac.uk",
+    "0.uk.pool.ntp.org",
+    "1.uk.pool.ntp.org",
+    "2.uk.pool.ntp.org",
+    "3.uk.pool.ntp.org",
+
+    // Canada
+    "chime.utoronto.ca",
+    "tick.utoronto.ca",
+    "time.nrc.ca",
+    "timelord.uregina.ca",
+    "tock.utoronto.ca",
+    "www1.cmc.ec.gc.ca",
+    "www2.cmc.ec.gc.ca",
+    "0.ca.pool.ntp.org",
+    "1.ca.pool.ntp.org",
+    "2.ca.pool.ntp.org",
+    "3.ca.pool.ntp.org",
+
+    // Japan
+    "ntp.nict.jp",
+    "0.jp.pool.ntp.org",
+    "1.jp.pool.ntp.org",
+    "2.jp.pool.ntp.org",
+    "3.jp.pool.ntp.org",
+
+    // Australia
+    "ntp.cs.mu.oz.au",
+    "augean.eleceng.adelaide.edu.au",
+    "0.au.pool.ntp.org",
+    "1.au.pool.ntp.org",
+    "2.au.pool.ntp.org",
+    "3.au.pool.ntp.org",
+
+    // Slovenia
+    "time.ijs.si",
+
+    // Austria
+    "0.at.pool.ntp.org",
+    "1.at.pool.ntp.org",
+    "2.at.pool.ntp.org",
+    "3.at.pool.ntp.org",
+
+    // ???
+    "clepsydra.dec.com",
+
+    // ... To be continued
+};
+
+bool InitWithHost(const std::string &strHostName, SOCKET &sockfd, socklen_t &servlen, struct sockaddr *pcliaddr) {
+  
+    sockfd = INVALID_SOCKET;
+
+    std::vector<CNetAddr> vIP;
+    bool fRet = LookupHost(strHostName.c_str(), vIP, 10, true);
+    if (!fRet) {
+        return false;
+    }
+
+    struct sockaddr_in servaddr;
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_port = htons(123);
+
+    bool found = false;
+    for(unsigned int i = 0; i < vIP.size(); i++) {
+        if ((found = vIP[i].GetInAddr(&servaddr.sin_addr)) != false) {
+            break;
+        }
+    }
+
+    if (!found) {
+        return false;
+    }
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if (sockfd == INVALID_SOCKET)
+        return false; // socket initialization error
+
+    if (connect(sockfd, (struct sockaddr *) &servaddr, sizeof(servaddr)) == -1 ) {
+        return false; // "connection" error
+    }
+
+
+    *pcliaddr = *((struct sockaddr *) &servaddr);
+    servlen = sizeof(servaddr);
+
+    return true;
+}
+
+bool InitWithRandom(SOCKET &sockfd, socklen_t &servlen, struct sockaddr *pcliaddr) {
+
+    for (int nAttempt = 0; nAttempt < nServersCount; nAttempt++) {
+        int nServerNum = GetRandInt(nServersCount);
+        if (InitWithHost(NtpServers[nServerNum], sockfd, servlen, pcliaddr)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+int64_t DoReq(SOCKET sockfd, socklen_t servlen, struct sockaddr cliaddr) {
+
+
+#ifdef WIN32
+    u_long nOne = 1;
+    if (ioctlsocket(sockfd, FIONBIO, &nOne) == SOCKET_ERROR) {
+        printf("ConnectSocket() : ioctlsocket non-blocking setting failed, error %d\n", WSAGetLastError());
+#else
+    if (fcntl(sockfd, F_SETFL, O_NONBLOCK) == SOCKET_ERROR) {
+        printf("ConnectSocket() : fcntl non-blocking setting failed, error %d\n", errno);
+#endif
+        return -2;
+    }
+
+    struct timeval timeout = {10, 0};
+    struct pkt *msg = new pkt;
+    struct pkt *prt  = new pkt;
+    time_t seconds_transmit;
+    int len = 48;
+
+    msg->li_vn_mode=227;
+    msg->stratum=0;
+    msg->ppoll=4;
+    msg->precision=0;
+    msg->rootdelay=0;
+    msg->rootdispersion=0;
+
+    msg->ref.Ul_i.Xl_i=0;
+    msg->ref.Ul_f.Xl_f=0;
+    msg->org.Ul_i.Xl_i=0;
+    msg->org.Ul_f.Xl_f=0;
+    msg->rec.Ul_i.Xl_i=0;
+    msg->rec.Ul_f.Xl_f=0;
+    msg->xmt.Ul_i.Xl_i=0;
+    msg->xmt.Ul_f.Xl_f=0;
+
+    int retcode = sendto(sockfd, (char *) msg, len, 0, &cliaddr, servlen);
+    if (retcode < 0) {
+        printf("sendto() failed: %d\n", retcode);
+        seconds_transmit = -3;
+        goto _end;
+    }
+
+    fd_set fdset;
+    FD_ZERO(&fdset);
+    FD_SET(sockfd, &fdset);
+
+    retcode = select(sockfd + 1, &fdset, NULL, NULL, &timeout);
+    if (retcode <= 0) {
+        printf("recvfrom() error\n");
+        seconds_transmit = -4;
+        goto _end;
+    }
+
+    recvfrom(sockfd, (char *) msg, len, 0, NULL, NULL);
+    ntohl_fp(&msg->xmt, &prt->xmt);
+    Ntp2Unix(prt->xmt.Ul_i.Xl_ui, seconds_transmit);
+
+    _end:
+
+    delete msg;
+    delete prt;
+
+    return seconds_transmit;
+}
+
+int64_t NtpGetTime(CNetAddr& ip) {
+    struct sockaddr cliaddr;
+
+    SOCKET sockfd;
+    socklen_t servlen;
+
+    if (!InitWithRandom(sockfd, servlen, &cliaddr))
+        return -1;
+
+    ip = CNetAddr(((sockaddr_in *)&cliaddr)->sin_addr);
+    int64_t nTime = DoReq(sockfd, servlen, cliaddr);
+
+    CloseSocket(sockfd);
+
+    return nTime;
+}
+
+int64_t NtpGetTime(const std::string &strHostName)
+{
+    struct sockaddr cliaddr;
+
+    SOCKET sockfd;
+    socklen_t servlen;
+
+    if (!InitWithHost(strHostName, sockfd, servlen, &cliaddr))
+        return -1;
+
+    int64_t nTime = DoReq(sockfd, servlen, cliaddr);
+
+    CloseSocket(sockfd);
+
+    return nTime;
+}
+
+// NTP server, which we unconditionally trust. This may be your own installation of ntpd somewhere, for example. 
+// "localhost" means "trust no one"
+std::string strTrustedUpstream = "localhost";
+
+// Current offset
+int64_t nNtpOffset = INT64_MAX;
+
+int64_t GetNtpOffset() {
+    return nNtpOffset;
+}

--- a/src/ntp.h
+++ b/src/ntp.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2013-2016 The NovaCoin developers
+// Copyright (c) 2015-2016 The Silk Network developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php
+
+#ifndef SILK_NTP_H
+#define SILK_NTP_H
+
+#include "net.h"
+
+// Get time from random server and return server address.
+int64_t NtpGetTime(CNetAddr& ip);
+
+// Get time from provided server.
+int64_t NtpGetTime(const std::string &strHostName);
+
+extern std::string strTrustedUpstream;
+
+// NTP time samples thread.
+void ThreadNtpSamples(void* parg);
+
+// NTP offset
+int64_t GetNtpOffset();
+
+#endif // SILK_NTP_H

--- a/src/rpc/rpcnet.cpp
+++ b/src/rpc/rpcnet.cpp
@@ -10,6 +10,7 @@
 #include "main.h"
 #include "net.h"
 #include "netbase.h"
+#include "ntp.h"
 #include "protocol.h"
 #include "sync.h"
 #include "timedata.h"
@@ -457,6 +458,31 @@ UniValue getcheckpoint(const UniValue& params, bool fHelp)
     return result;
 }
 
+UniValue ntptime(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "ntptime [ntpserver]\n"
+            "Returns current time from specific or random NTP server.");
+
+    int64_t nTime;
+    if (params.size() > 0)
+    {
+        std::string strHostName = params[0].get_str();
+        nTime = NtpGetTime(strHostName);
+    }
+    else
+        nTime = NtpGetTime(nullptr);
+
+    if (nTime < 0)
+        throw runtime_error("Request error");
+
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("epoch", nTime));
+    obj.push_back(Pair("time", DateTimeStrFormat(nTime)));
+    return obj;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode threadSafe reqWallet
   //  --------------------- ------------------------  -----------------------  ---------- ---------- ---------
@@ -468,6 +494,7 @@ static const CRPCCommand commands[] =
     { "network",            "getpeerinfo",            &getpeerinfo,            true,      false,      false },
     { "network",            "ping",                   &ping,                   true,      false,      false },
     { "network",            "getcheckpoint",          &getcheckpoint,          false,     false,      false },
+    { "network",            "ntptime",                &ntptime,                true,      true,       false },
 };
 
 void RegisterNetRPCCommands(CRPCTable &tableRPC)

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -10,17 +10,18 @@
 
 #include "utiltime.h"
 
+#include "ntp.h"
+
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
 using namespace std;
 
-static int64_t nMockTime = 0;  //! For unit testing
+static int64_t nMockTime = 0; //! For unit testing
 
+// System Clock
 int64_t GetTime()
 {
-    if (nMockTime) return nMockTime;
-
     return time(NULL);
 }
 


### PR DESCRIPTION
<!--- Remove sections that do not apply -->


#### What is the purpose of this pull request (PR)?
Adds a new check to CheckTransaction() which looks at the timestamp of the staked block in order to prevent blocks that have been generated outside of the maximum time drift parameter.


#### Any background context to help the reviewer?
Each second, your wallet generates a single hash for every UTXO within your wallet. So, for each average blocktime 64 hashes will be generated on average per UTXO per SLK block. It is not difficult to customize the code to allow blockhashing minutes into the future and then sidechain those blocks and submit them. As long as this artificial sidechain is created so that when it's creator supplants the organic chain, the attacker gains an extraordinary advantage. 

Silk currently has an allowable drift time of 15 minutes, which can easily be taken advantage of and can create a situation where the chain is attacked by many of theses drifiting stakers all at once which would then create an artificially high difficulty and in the long run destroy the entire protocol.

This small check is a start to fix this vulnerability among other upcoming changes.

**I would suggest we lower the max time drift from 15 minutes to 128 seconds.**

